### PR TITLE
Fix Realm sorting/filtering

### DIFF
--- a/RealmPlatform/Repository/Repository.swift
+++ b/RealmPlatform/Repository/Repository.swift
@@ -43,11 +43,11 @@ final class Repository<T:RealmRepresentable>: AbstractRepository where T == T.Re
                         sortDescriptors: [NSSortDescriptor] = []) -> Observable<[T]> {
         return Observable.deferred {
                     let realm = self.realm
-                    let objects = realm.objects(T.RealmType.self)
-//            The implementation is broken since we are not using predicate and sortDescriptors
-//            but it cause compiler to crash with xcode 8.3 ¯\_(ツ)_/¯
-//                            .filter(predicate)
-//                            .sorted(by: sortDescriptors.map(SortDescriptor.init))
+                    var objects = realm.objects(T.RealmType.self)
+                        .filter(predicate)
+                    if !sortDescriptors.isEmpty {
+                        objects = objects.sorted(by: sortDescriptors.map(SortDescriptor.init))
+                    }
 
                     return Observable.array(from: objects)
                             .mapToDomain()

--- a/RealmPlatform/Utility/Extensions/Realm+Ext.swift
+++ b/RealmPlatform/Utility/Extensions/Realm+Ext.swift
@@ -11,12 +11,14 @@ extension Object {
     }
 }
 
-//extension SortDescriptor {
-//    init(sortDescriptor: NSSortDescriptor) {
-//        self.keyPath = sortDescriptor.key ?? ""
-//        self.ascending = sortDescriptor.ascending
-//    }
-//}
+extension SortDescriptor {
+    /// Convenience initializer to bridge `NSSortDescriptor` used across
+    /// the code base with Realm's `SortDescriptor` type.
+    /// - Parameter sortDescriptor: descriptor describing the sort order.
+    init(sortDescriptor: NSSortDescriptor) {
+        self.init(keyPath: sortDescriptor.key ?? "", ascending: sortDescriptor.ascending)
+    }
+}
 
 extension Reactive where Base == Realm {
     func save<R: RealmRepresentable>(entity: R, update: Realm.UpdatePolicy = .all) -> Observable<Void> where R.RealmType: Object  {


### PR DESCRIPTION
## Summary
- implement a `SortDescriptor` initializer bridging from `NSSortDescriptor`
- use predicate filtering and sorting in Realm repository queries

## Testing
- `N/A` - project uses Xcode and cannot run tests in this environment

------
https://chatgpt.com/codex/tasks/task_e_68456e77975c8321a27a1f16fa2399c2